### PR TITLE
Add model ids corresponding to inference profiles supported by AWS Bedrock

### DIFF
--- a/src/backend/base/langflow/base/models/aws_constants.py
+++ b/src/backend/base/langflow/base/models/aws_constants.py
@@ -3,6 +3,10 @@ AWS_MODEL_IDs = [
     "amazon.titan-text-express-v1",
     "amazon.titan-text-lite-v1",
     "amazon.titan-text-premier-v1:0",
+    # Amazon Nova models for Cross Region Inference
+    "us.amazon.nova-lite-v1:0",
+    "us.amazon.nova-pro-v1:0",
+    "us.amazon.nova-micro-v1:0",
     # Anthropic Models
     "anthropic.claude-v2",
     "anthropic.claude-v2:1",
@@ -13,6 +17,20 @@ AWS_MODEL_IDs = [
     "anthropic.claude-3-5-haiku-20241022-v1:0",
     "anthropic.claude-3-opus-20240229-v1:0",
     "anthropic.claude-instant-v1",
+    # Anthropic models for Cross Region Inference
+    # See https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-support.html
+    "us.anthropic.claude-3-sonnet-20240229-v1:0",
+    "us.anthropic.claude-3-opus-20240229-v1:0",
+    "us.anthropic.claude-3-haiku-20240307-v1:0",
+    "us.anthropic.claude-3-5-sonnet-20240620-v1:0",
+    "us.anthropic.claude-3-5-sonnet-20241022-v2:0",
+    "us.anthropic.claude-3-5-haiku-20241022-v1:0",
+    "eu.anthropic.claude-3-sonnet-20240229-v1:0",
+    "eu.anthropic.claude-3-5-sonnet-20240620-v1:0",
+    "eu.anthropic.claude-3-haiku-20240307-v1:0",
+    "apac.anthropic.claude-3-sonnet-20240229-v1:0",
+    "apac.anthropic.claude-3-5-sonnet-20240620-v1:0",
+    "apac.anthropic.claude-3-haiku-20240307-v1:0",
     # AI21 Labs Models
     "ai21.jamba-instruct-v1:0",
     "ai21.j2-mid-v1",
@@ -36,6 +54,18 @@ AWS_MODEL_IDs = [
     "meta.llama3-2-3b-instruct-v1:0",
     "meta.llama3-2-11b-instruct-v1:0",
     "meta.llama3-2-90b-instruct-v1:0",
+    # Meta models for Cross Region Inference
+    # See https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-support.html
+    "us.meta.llama3-2-11b-instruct-v1:0",
+    "us.meta.llama3-2-3b-instruct-v1:0",
+    "us.meta.llama3-2-90b-instruct-v1:0",
+    "us.meta.llama3-2-1b-instruct-v1:0",
+    "us.meta.llama3-1-8b-instruct-v1:0",
+    "us.meta.llama3-1-70b-instruct-v1:0",
+    "us.meta.llama3-3-70b-instruct-v1:0",
+    "us.meta.llama3-1-405b-instruct-v1:0",
+    "eu.meta.llama3-2-3b-instruct-v1:0",
+    "eu.meta.llama3-2-1b-instruct-v1:0",
     # Mistral AI Models
     "mistral.mistral-7b-instruct-v0:2",
     "mistral.mixtral-8x7b-instruct-v0:1",


### PR DESCRIPTION

AWS has something called "Inference Profiles" for performing cross-region inference for calling Bedrock APIs for specific models from specific regions. This is typically used by using particular model ids, which is added with this commit.

Read more here:
- https://docs.aws.amazon.com/bedrock/latest/userguide/cross-region-inference.html
- https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-support.html

I noticed this when setting up Langflow and trying to use the models in Bedrock. It is a simple constants change for now. But maybe is it possible to allow a user to type-in a model id, if in the dropdown the option user tries to choose does not exist? Because API providers would keep adding new models every other week and we would need to keep playing catch up :)